### PR TITLE
Fixing message routing for sim frame

### DIFF
--- a/vscode/resources/script.js
+++ b/vscode/resources/script.js
@@ -8,12 +8,12 @@
         window.addEventListener("message", function (m) {
             console.log("Got Message", m.origin)
 
-            if (m.origin === "vscode-resource://") {
-                console.log("Forward to vscode");
-                vscode.postMessage(m.data);
-            } else if (m.origin === "null") {
+            if (m.data._fromVscode) {
                 console.log("Forward to sim-frame");
                 frame.contentWindow.postMessage(m.data, "*");
+            } else {
+                console.log("Forward to vscode");
+                vscode.postMessage(m.data);
             }
         });
         ["build", "console"].forEach(id => {

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -257,7 +257,7 @@ async function simulateCommand() {
         sim.Simulator.createOrShow(globalContext, project.cache);
         if (watcher) sim.Simulator.currentSimulator.addDisposable(watcher);
 
-        progress.report({ increment: 10, message: "Compiling..." })
+        progress.report({ increment: 20, message: "Compiling..." })
 
         const res = await justBuild()
         //if (res.diagnostics.length)

--- a/vscode/src/simulator.ts
+++ b/vscode/src/simulator.ts
@@ -8,6 +8,7 @@ interface SimulatorRunMessage {
     type: "run";
     code: string;
     storedState: any;
+    _fromVscode?: boolean;
 }
 
 let extensionContext: vscode.ExtensionContext;
@@ -106,7 +107,8 @@ export class Simulator {
             const msg: SimulatorRunMessage = {
                 type: "run",
                 code: this.binaryJS,
-                storedState: this.simState
+                storedState: this.simState,
+                _fromVscode: true
                 // breakOnStart: true
             }
             this.panel.webview.postMessage(msg);
@@ -162,6 +164,7 @@ export class Simulator {
 
     postMessaage(msg: any) {
         this.panel.webview.postMessage(msg);
+        msg._fromVscode = true;
         console.log("sending", msg)
     }
 


### PR DESCRIPTION
The origin for all messages is just "null" for whatever reason. Fixing it by adding a property to indicate the message source.