### PR TITLE
add option to serve built files in a remote environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Use `--watch`, or `-w`, with `mkc build` to automatically watch changes in sourc
 mkc -w
 ```
 
+### mkc build --watch --serve
+
+When building within a virtual machine without USB access, the `--serve`, or `-s` option starts a local web server
+that serves the compiled binaries by the build process.
+
+```
+mkc -w -s
+```
+
 ### Built files in codespace
 
 From Visual Studio Code, browse to the built folder and right click `Download` on the desired file.


### PR DESCRIPTION
In codespace or VM, there is no access to USB drives and the deploy story does not work. This change mounts a barebone webserver that serves the built files.