### PR TITLE
feat: addDependency supporting builtin dependencies 

### DIFF
--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -682,8 +682,6 @@ async function addDependency(prj: mkc.Project, repo: string, name: string) {
             ?.bundleddirs
             ?.map((dir: string) => /^libs\/(.+)/.exec(dir)?.[1])
             ?.filter((dir: string) => !!dir);
-            // ?.filter((dir: string) => !/---.+$/.test(dir))
-            // filter out hw variants? does it matter for e.g. game---light?
         const builtInPkg = bundledPkgs?.find(dir => dir === repo);
 
         if (!builtInPkg) {

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -643,30 +643,30 @@ export async function stackCommand(opts: ProjectOptions) {
 }
 
 interface AddOptions extends ProjectOptions { }
-export async function addCommand(repo: string, name: string, opts: AddOptions) {
+export async function addCommand(pkg: string, name: string, opts: AddOptions) {
     applyGlobalOptions(opts)
     opts.pxtModules = true
 
-    msg(`adding ${repo}`)
+    msg(`adding ${pkg}`)
     const prj = await resolveProject(opts)
-    await addDependency(prj, repo, name)
+    await addDependency(prj, pkg, name)
     prj.mainPkg = null
     await prj.maybeWritePxtModulesAsync()
 }
 
-async function addDependency(prj: mkc.Project, repo: string, name: string) {
-    repo = repo.toLowerCase().trim()
-    if (repo === "jacdac") repo = "https://github.com/microsoft/pxt-jacdac"
-    else if (/^jacdac-/.test(repo)) {
+async function addDependency(prj: mkc.Project, pkg: string, name: string) {
+    pkg = pkg.toLowerCase().trim()
+    if (pkg === "jacdac") pkg = "https://github.com/microsoft/pxt-jacdac"
+    else if (/^jacdac-/.test(pkg)) {
         const exts = await jacdacMakeCodeExtensions()
-        const ext = exts.find(ext => ext.client.name === repo)
+        const ext = exts.find(ext => ext.client.name === pkg)
         if (ext) {
             info(`found jacdac ${ext.client.repo}`)
-            repo = ext.client.repo
+            pkg = ext.client.repo
         }
     }
 
-    const rid = parseRepoId(repo);
+    const rid = parseRepoId(pkg);
     const pxtJson = await prj.readPxtConfig();
     if (rid) {
         const d = await fetchExtension(rid.slug);
@@ -682,11 +682,11 @@ async function addDependency(prj: mkc.Project, repo: string, name: string) {
             ?.bundleddirs
             ?.map((dir: string) => /^libs\/(.+)/.exec(dir)?.[1])
             ?.filter((dir: string) => !!dir);
-        const builtInPkg = bundledPkgs?.find(dir => dir === repo);
+        const builtInPkg = bundledPkgs?.find(dir => dir === pkg);
 
         if (!builtInPkg) {
             const possiblyMeant = bundledPkgs
-                ?.filter(el => el?.toLowerCase().indexOf(repo) !== -1);
+                ?.filter(el => el?.toLowerCase().indexOf(pkg) !== -1);
             if (possiblyMeant?.length) {
                 error(`Did you mean ${possiblyMeant?.join(", ")}?`);
             } else {
@@ -696,7 +696,7 @@ async function addDependency(prj: mkc.Project, repo: string, name: string) {
         }
 
         const collidingHwVariant = Object.keys(pxtJson.dependencies)
-            .find(dep => dep.toLowerCase().replace(/---.+$/, "") === repo.replace(/---.+$/, "")
+            .find(dep => dep.toLowerCase().replace(/---.+$/, "") === pkg.replace(/---.+$/, "")
                 && pxtJson.dependencies[dep] === "*");
 
         if (collidingHwVariant) {

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -679,11 +679,12 @@ async function addDependency(prj: mkc.Project, repo: string, name: string) {
         const builtInPkg = bundledPkgs?.find(dir => dir === repo);
 
         if (!builtInPkg) {
-            error("unknown package, try https://github.com/.../... for github extensions");
             const possiblyMeant = bundledPkgs
                 ?.filter(el => el?.toLowerCase().indexOf(repo) !== -1);
             if (possiblyMeant?.length) {
                 error(`Did you mean ${possiblyMeant?.join(", ")}?`);
+            } else {
+                error("unknown package, try https://github.com/.../... for github extensions");
             }
             host().exitWithStatus(1)
         }

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -666,16 +666,16 @@ async function addDependency(prj: mkc.Project, repo: string, name: string) {
         }
     }
 
-    const rid = parseRepoId(repo)
-    const pxtJson = await prj.readPxtConfig()
+    const rid = parseRepoId(repo);
+    const pxtJson = await prj.readPxtConfig();
     if (rid) {
-        const d = await fetchExtension(rid.slug)
+        const d = await fetchExtension(rid.slug);
         const dname =
             name ||
-            join(rid.project, rid.fileName).replace(/^pxt-/, "").replace("/", "-")
+            join(rid.project, rid.fileName).replace(/^pxt-/, "").replace("/", "-");
 
-        pxtJson.dependencies[dname] = `github:${rid.fullName}#${d.version ? `v${d.version}` : d.defaultBranch}`
-        info(`adding dependency ${dname}=${pxtJson.dependencies[dname]}`)
+        pxtJson.dependencies[dname] = `github:${rid.fullName}#${d.version ? `v${d.version}` : d.defaultBranch}`;
+        info(`adding dependency ${dname}=${pxtJson.dependencies[dname]}`);
     } else {
         const appTarget = await prj.service.languageService.getAppTargetAsync();
         const bundledPkgs: string[] = appTarget
@@ -692,18 +692,19 @@ async function addDependency(prj: mkc.Project, repo: string, name: string) {
             } else {
                 error("unknown package, try https://github.com/.../... for github extensions");
             }
-            host().exitWithStatus(1)
+            host().exitWithStatus(1);
         }
 
         const collidingHwVariant = Object.keys(pxtJson.dependencies)
             .find(dep => dep.toLowerCase().replace(/---.+$/, "") === repo.replace(/---.+$/, "")
                 && pxtJson.dependencies[dep] === "*");
+
         if (collidingHwVariant) {
             delete pxtJson.dependencies[collidingHwVariant];
         }
 
         pxtJson.dependencies[builtInPkg] = "*";
-        info(`adding builtin dependency ${builtInPkg}=*`)
+        info(`adding builtin dependency ${builtInPkg}=*`);
     }
 
     await host().writeFileAsync("pxt.json", JSON.stringify(pxtJson, null, 4), "utf8")

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -697,6 +697,13 @@ async function addDependency(prj: mkc.Project, repo: string, name: string) {
             host().exitWithStatus(1)
         }
 
+        const collidingHwVariant = Object.keys(pxtJson.dependencies)
+            .find(dep => dep.toLowerCase().replace(/---.+$/, "") === repo.replace(/---.+$/, "")
+                && pxtJson.dependencies[dep] === "*");
+        if (collidingHwVariant) {
+            delete pxtJson.dependencies[collidingHwVariant];
+        }
+
         pxtJson.dependencies[builtInPkg] = "*";
         info(`adding builtin dependency ${builtInPkg}=*`)
     }


### PR DESCRIPTION
Support adding built in extensions via add dependency. Fix https://github.com/microsoft/pxt-mkc/issues/53, with https://github.com/microsoft/pxt-mkc/issues/51 partly for builtins / doesn't do a gh search for repos but can add that