### PR TITLE
feat: command to get target config

### DIFF
--- a/packages/makecode-browser/src/languageService.ts
+++ b/packages/makecode-browser/src/languageService.ts
@@ -61,6 +61,10 @@ export class BrowserLanguageService implements LanguageService {
         return res.appTarget;
     }
 
+    async getTargetConfigAsync(): Promise<any> {
+        return this.editor.targetConfig;
+    }
+
     async supportsGhPackagesAsync(): Promise<boolean> {
         const res = await this.sendWorkerRequestAsync({
             type: "supportsGhPackages"

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -511,6 +511,11 @@ export async function getAppTargetAsync(opts: ProjectOptions) {
     return await prj.service.languageService.getAppTargetAsync();
 }
 
+export async function getTargetConfigAsync(opts: ProjectOptions) {
+    const prj = await resolveProject(opts)
+    return await prj.service.languageService.getTargetConfigAsync();
+}
+
 async function jacdacMakeCodeExtensions() {
     let data: {
         service: string

--- a/packages/makecode-core/src/downloader.ts
+++ b/packages/makecode-core/src/downloader.ts
@@ -135,11 +135,10 @@ export async function downloadAsync(
         const month = `${currentDate.getUTCMonth()}`.padStart(2, "0");
         const day = `${currentDate.getUTCDay()}`.padStart(2, "0");
         const cacheBustId = `${year}${month}${day}`;
-        return await requestAsync({
+        const resp = await requestAsync({
             url: `${cdnUrl}/api/config/${target}/targetconfig${version ? `/v${version}`: ""}?cdn=${cacheBustId}`
-        }).then(trgCfg => {
-            return JSON.parse(trgCfg.text);
         });
+        return JSON.parse(resp.text);
     }
 
     if (useCached && info.manifest && info.webConfig) {
@@ -189,7 +188,7 @@ export async function downloadAsync(
     info.versionNumber = (info.versionNumber || 0) + 1
     info.updateCheckedAt = Date.now()
 
-    await saveFileAsync("pxtworker.js")
+    await saveFileAsync("pxtworker.js");
     const targetJsonBuf = await saveFileAsync("target.json");
     const targetJson = JSON.parse(
         host().bufferToString(targetJsonBuf)

--- a/packages/makecode-core/src/host.ts
+++ b/packages/makecode-core/src/host.ts
@@ -55,6 +55,7 @@ export interface LanguageService {
     setWebConfigAsync(config: WebConfig): Promise<void>;
     getWebConfigAsync(): Promise<WebConfig>;
     getAppTargetAsync(): Promise<any>;
+    getTargetConfigAsync(): Promise<any>;
     supportsGhPackagesAsync(): Promise<boolean>;
     setHwVariantAsync(variant: string): Promise<void>;
     getHardwareVariantsAsync(): Promise<pxt.PackageConfig[]>;

--- a/packages/makecode-core/src/mkc.ts
+++ b/packages/makecode-core/src/mkc.ts
@@ -29,7 +29,8 @@ export interface DownloadedEditor {
     website: string
     pxtWorkerJs: string
     targetJson: any
-    webConfig: downloader.WebConfig
+    webConfig: downloader.WebConfig,
+    targetConfig: any
 }
 
 export interface Package {

--- a/packages/makecode-node/src/languageService.ts
+++ b/packages/makecode-node/src/languageService.ts
@@ -72,6 +72,10 @@ export class NodeLanguageService implements LanguageService {
         return this.runSync("pxt.appTarget");
     }
 
+    async getTargetConfigAsync(): Promise<any> {
+        return this.editor.targetConfig;
+    }
+
     async supportsGhPackagesAsync(): Promise<boolean> {
         return !!this.runSync("pxt.simpleInstallPackagesAsync")
     }


### PR DESCRIPTION
Fetch and save target config and expose to users. Since this is not directly tied to releases / is live I made it also update when we have checked for updates & determined we don't need to pull the full target.