### PR TITLE
fix: make it so updating sim doesn't force redownload

### DIFF
--- a/packages/makecode-core/src/downloader.ts
+++ b/packages/makecode-core/src/downloader.ts
@@ -123,7 +123,7 @@ function log(msg: string) {
 export async function downloadAsync(
     cache: mkc.Cache,
     webAppUrl: string,
-    useCached = false
+    forceCheckUpdates = false
 ) {
     const infoBuf = await cache.getAsync(webAppUrl + "-info")
     const info: DownloadInfo = infoBuf
@@ -141,7 +141,7 @@ export async function downloadAsync(
         return JSON.parse(resp.text);
     }
 
-    if (useCached && info.manifest && info.webConfig) {
+    if (forceCheckUpdates && info.manifest && info.webConfig) {
         let needsUpdate = false
         if (
             !info.updateCheckedAt ||
@@ -171,8 +171,8 @@ export async function downloadAsync(
             }
         }
         if (!needsUpdate) return loadFromCacheAsync()
-    } else if (useCached) {
-        if (!(await hasNewManifestAsync())) return loadFromCacheAsync()
+    } else {
+        if (!(await hasNewManifestAsync())) return loadFromCacheAsync();
     }
 
     log("Download new webapp")


### PR DESCRIPTION
I had added this line in https://github.com/microsoft/pxt-mkc/pull/93 as it felt wrong, but it ends up slowing down sim load as that goes through with a 'force update' path. I renamed the parameter to feel a bit better when we still send back cached info when available