### PR TITLE
fix: grayscale sim when stopped to match webapp

### DIFF
--- a/packages/makecode-core/simloader/index.html
+++ b/packages/makecode-core/simloader/index.html
@@ -49,6 +49,10 @@
                 z-index: -1;
             }
 
+            .grayscale {
+                filter: grayscale(1);
+            }
+
             .lds-ripple div {
                 position: absolute;
                 border: 4px solid #fff;

--- a/packages/makecode-core/simloader/loader.ts
+++ b/packages/makecode-core/simloader/loader.ts
@@ -111,6 +111,8 @@ function makeCodeRun(options) {
     function startSim() {
         if (!code || !isReady || started) return;
         setState("run");
+        const frame = document.getElementById("simframe");
+        frame.classList.remove("grayscale");
         started = true;
         const runMsg = {
             type: "run",
@@ -135,6 +137,8 @@ function makeCodeRun(options) {
 
     function stopSim() {
         setState("stopped");
+        const frame = document.getElementById("simframe");
+        frame.classList.add("grayscale");
         postMessage({
             type: "stop",
         });
@@ -215,6 +219,8 @@ function makeCodeRun(options) {
                 else if (d.type == "fetch-js") {
                     pendingMessages[d.id](d.text);
                     delete pendingMessages[d.id];
+                } else if (d.type === "stop-sim") {
+                    stopSim();
                 }
             }
         },


### PR DESCRIPTION
Add a stop-sim message listener, and gray out sim when it has been explicit stopped.