### PR TITLE
fix npm i makecode / makecode-browser

### DIFF
--- a/packages/makecode-browser/package.json
+++ b/packages/makecode-browser/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "makecode-core": "^0.0.1"
+    "makecode-core": "^1.3.0"
   },
   "release": {
     "branch": "master",

--- a/packages/makecode-node/package.json
+++ b/packages/makecode-node/package.json
@@ -48,7 +48,7 @@
     "glob": "^7.2.0",
     "node-watch": "^0.7.2",
     "semver": "^7.3.7",
-    "makecode-core": "^0.0.1"
+    "makecode-core": "^1.3.0"
   },
   "release": {
     "branch": "master",


### PR DESCRIPTION
fix https://github.com/microsoft/pxt-mkc/issues/97

the build over there just npm i's makecode(-node), and since the core dep is out of date that resulted in a bad build with nothing built https://www.npmjs.com/package/makecode-core/v/0.0.1
<img width="419" alt="image" src="https://user-images.githubusercontent.com/5615930/218940374-8f9f4485-c09b-4407-80c6-7a6e37850726.png">
