### PR TITLE
fix: change ws to release package bump

### DIFF
--- a/packages/makecode-browser/src/types.d.ts
+++ b/packages/makecode-browser/src/types.d.ts
@@ -142,18 +142,39 @@ interface SetCompileSwitchesResponse extends BaseResponse {
     type: "setCompileSwitches";
 }
 
-type ClientToWorkerRequest = RegisterDriverCallbacksRequest | SetWebConfigRequest | GetWebConfigRequest
-| GetAppTargetRequest | SupportsGhPackagesRequest | SetHwVariantRequest | GetHardwareVariantsRequest
-| GetBundledPackageConfigsRequest | GetCompileOptionsAsyncRequest | InstallGhPackagesAsyncRequest
-| PerformOperationRequest | SetProjectTextRequest | EnableExperimentalHardwareRequest
-| EnableDebugRequest | SetCompileSwitchesRequest;
+type ClientToWorkerRequest =
+    | RegisterDriverCallbacksRequest
+    | SetWebConfigRequest
+    | GetWebConfigRequest
+    | GetAppTargetRequest
+    | SupportsGhPackagesRequest
+    | SetHwVariantRequest
+    | GetHardwareVariantsRequest
+    | GetBundledPackageConfigsRequest
+    | GetCompileOptionsAsyncRequest
+    | InstallGhPackagesAsyncRequest
+    | PerformOperationRequest
+    | SetProjectTextRequest
+    | EnableExperimentalHardwareRequest
+    | EnableDebugRequest
+    | SetCompileSwitchesRequest
 
-type ClientToWorkerRequestResponse = RegisterDriverCallbacksResponse | SetWebConfigResponse | GetWebConfigResponse
-| GetAppTargetResponse | SupportsGhPackagesResponse | SetHwVariantResponse | GetHardwareVariantsResponse
-| GetBundledPackageConfigsResponse | GetCompileOptionsAsyncResponse | InstallGhPackagesAsyncResponse
-| PerformOperationResponse | SetProjectTextResponse | EnableExperimentalHardwareResponse
-| EnableDebugResponse | SetCompileSwitchesResponse;
-
+type ClientToWorkerRequestResponse =
+    | RegisterDriverCallbacksResponse
+    | SetWebConfigResponse
+    | GetWebConfigResponse
+    | GetAppTargetResponse
+    | SupportsGhPackagesResponse
+    | SetHwVariantResponse
+    | GetHardwareVariantsResponse
+    | GetBundledPackageConfigsResponse
+    | GetCompileOptionsAsyncResponse
+    | InstallGhPackagesAsyncResponse
+    | PerformOperationResponse
+    | SetProjectTextResponse
+    | EnableExperimentalHardwareResponse
+    | EnableDebugResponse
+    | SetCompileSwitchesResponse
 
 interface BaseWorkerToClientRequest extends WorkerMessage {
     kind: "worker-to-client";

--- a/packages/makecode-node/src/bump.ts
+++ b/packages/makecode-node/src/bump.ts
@@ -18,7 +18,7 @@ export interface SpawnOptions {
 
 export function spawnAsync(opts: SpawnOptions) {
     opts.pipe = false
-    return spawnWithPipeAsync(opts).then(() => { })
+    return spawnWithPipeAsync(opts).then(() => {})
 }
 
 export function spawnWithPipeAsync(opts: SpawnOptions) {


### PR DESCRIPTION
https://github.com/microsoft/pxt-mkc/pull/98 didn't run semantic release for these two, I can't tell immediately if it was because it only changed package.json or if it was because because I prefixed it with `fix blah` instead of `fix: blah`. But I think this should release those changes so microcode works again?