### PR TITLE
feat: add binary path to compile result

### DIFF
--- a/packages/makecode-browser/tsconfig.json
+++ b/packages/makecode-browser/tsconfig.json
@@ -3,7 +3,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "module": "commonjs",
-        "target": "es6",
+        "target": "ES2017",
         "outDir": "built",
         "lib": ["es6", "DOM"],
         "sourceMap": true,

--- a/packages/makecode-browser/worker/tsconfig.json
+++ b/packages/makecode-browser/worker/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "noImplicitReturns": true,
-        "target": "es6",
+        "target": "ES2017",
         "outDir": "built",
         "lib": ["es6", "dom"],
         "sourceMap": false,

--- a/packages/makecode-core/simloader/tsconfig.json
+++ b/packages/makecode-core/simloader/tsconfig.json
@@ -1,7 +1,7 @@
-{    
+{
     "compilerOptions": {
         "noImplicitReturns": true,
-        "target": "es6",
+        "target": "ES2017",
         "outDir": "built",
         "lib": ["es6", "dom"],
         "sourceMap": false,

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -210,10 +210,10 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
 
     outputs.push(prj.outputPrefix)
     const compileRes = await buildOnePrj(opts, prj)
+    const firmwareName = compileRes.success && ["binary.uf2", "binary.hex", "binary.elf"].filter(
+        f => !!compileRes.outfiles[f]
+    )[0];
     if (compileRes.success && opts.deploy) {
-        const firmwareName = ["binary.uf2", "binary.hex", "binary.elf"].filter(
-            f => !!compileRes.outfiles[f]
-        )[0]
         if (!firmwareName) {
             // something went wrong here
             error(
@@ -291,6 +291,10 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
             )
             await host().writeFileAsync(fn, total)
         }
+    }
+
+    if (compileRes && outputs.length && firmwareName) {
+        compileRes.binaryPath = outputs[0] + "/" + firmwareName;
     }
 
     if (success) {

--- a/packages/makecode-core/src/service.ts
+++ b/packages/makecode-core/src/service.ts
@@ -83,6 +83,7 @@ export interface CompileResult {
     times: pxt.Map<number>
     // breakpoints?: Breakpoint[];
     usedArguments?: pxt.Map<string[]>
+    binaryPath?: string;
 }
 
 export interface ServiceUser {

--- a/packages/makecode-core/tsconfig.json
+++ b/packages/makecode-core/tsconfig.json
@@ -3,7 +3,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "module": "commonjs",
-        "target": "es6",
+        "target": "ES2017",
         "outDir": "built",
         "lib": ["es6", "DOM"],
         "sourceMap": true,

--- a/packages/makecode-node/tsconfig.json
+++ b/packages/makecode-node/tsconfig.json
@@ -3,7 +3,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "module": "commonjs",
-        "target": "es6",
+        "target": "ES2017",
         "outDir": "built",
         "lib": ["es6", "DOM"],
         "sourceMap": true,


### PR DESCRIPTION
...and also sneakily change the build target to ES2017 so that we the compiled JS uses native async/await instead of converting it

The path is needed for https://github.com/microsoft/pxt-vscode-web/issues/51