### PR TITLE
fix: memory leak in makecode-browser

### DIFF
--- a/packages/makecode-browser/src/languageService.ts
+++ b/packages/makecode-browser/src/languageService.ts
@@ -20,7 +20,7 @@ export class BrowserLanguageService implements LanguageService {
         const workerBlob = new Blob([workerSource], { type: "application/javascript" });
 
         this.worker = new Worker(URL.createObjectURL(workerBlob));
-        this.worker.onmessage = ev => {
+        this.worker.onmessage = (ev) => {
             if (ev.data.kind) {
                 this.onWorkerRequestReceived(ev.data);
             }
@@ -28,6 +28,10 @@ export class BrowserLanguageService implements LanguageService {
                 this.onWorkerResponseReceived(ev.data);
             }
         }
+    }
+
+    dispose() {
+        this.worker.terminate();
     }
 
     async registerDriverCallbacksAsync(callbacks: SimpleDriverCallbacks): Promise<void> {

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -125,6 +125,23 @@ export async function cleanCommand(opts: CleanOptions) {
     msg("run `mkc init` again to setup your project")
 }
 
+let prjCache: pxt.Map<mkc.Project> = {};
+
+export async function clearProjectCache() {
+    for (const prjdir of Object.keys(prjCache)) {
+        const prj = prjCache[prjdir];
+        prj.service?.dispose?.();
+    }
+    prjCache = {};
+}
+
+function getCachedProject(prjdir: string) {
+    if (!prjCache[prjdir]) {
+        prjCache[prjdir] = new mkc.Project(prjdir);
+    }
+    return prjCache[prjdir];
+}
+
 export async function resolveProject(opts: ProjectOptions, quiet = false) {
     const prjdir = await files.findProjectDirAsync()
     if (!prjdir) {
@@ -137,8 +154,8 @@ export async function resolveProject(opts: ProjectOptions, quiet = false) {
         if (cfgFolder) opts.configPath = path.join(cfgFolder, "mkc.json")
     }
 
-    log(`using project: ${prjdir}/pxt.json`)
-    const prj = new mkc.Project(prjdir)
+    log(`using project: ${prjdir}/pxt.json`);
+    const prj = getCachedProject(prjdir);
 
     if (opts.configPath) {
         log(`using config: ${opts.configPath}`)

--- a/packages/makecode-core/src/host.ts
+++ b/packages/makecode-core/src/host.ts
@@ -68,6 +68,8 @@ export interface LanguageService {
     enableExperimentalHardwareAsync(): Promise<void>;
     enableDebugAsync(): Promise<void>;
     setCompileSwitchesAsync(flags: string): Promise<void>
+
+    dispose?: () => void;
 }
 
 let host_: Host;

--- a/packages/makecode-core/src/mkc.ts
+++ b/packages/makecode-core/src/mkc.ts
@@ -238,6 +238,9 @@ export class Project {
             newEditor.versionNumber != this.editor.versionNumber
         ) {
             this.editor = newEditor
+            if (this.service) {
+                this.service.dispose();
+            }
             this.service = new service.Ctx(this.editor)
             return true
         } else {

--- a/packages/makecode-core/src/service.ts
+++ b/packages/makecode-core/src/service.ts
@@ -282,4 +282,8 @@ export class Ctx {
 
         return hwVariants
     }
+
+    dispose() {
+        this.languageService?.dispose?.();
+    }
 }


### PR DESCRIPTION
Right now we're spinning up a new worker on any request that needs a language service. This only takes ~50ms to spin up, but we're also leaving the old one around, increasing memory usage by ~5-10mb per compile

fix https://github.com/microsoft/vscode-makecode/issues/78

(and to confirm, this shouldn't have affected makecode-node at all as that spins up a new node process whenever you call into it from cli, correct?)