### PR TITLE
fix: point at arcade live site by default, not beta

### DIFF
--- a/packages/makecode-core/src/loader.ts
+++ b/packages/makecode-core/src/loader.ts
@@ -20,7 +20,7 @@ export const descriptors: TargetDescriptor[] = [
         targetId: "arcade",
         name: "MakeCode Arcade",
         description: "Old school games",
-        website: "https://arcade.makecode.com/beta",
+        website: "https://arcade.makecode.com/",
         corepkg: "device",
     },
     {


### PR DESCRIPTION
arcade has released relatively recently and is effectively up to date across pxt/pxt-common-packages/pxt-arcade, so good time to pin down this default value

part of https://github.com/microsoft/vscode-makecode/issues/81, there's another ref over in that repo