### PR TITLE
fix: hide mkc.json for vscode extension, suggest vscode extension

### DIFF
--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -484,8 +484,20 @@ export async function initCommand(
                 },
                 "files.exclude": {
                     "**/pxt_modules": true,
-                    "**/.pxt": true
+                    "**/.pxt": true,
+                    "**/mkc.json": true
                 }
+            }, null, 4)
+        );
+    }
+
+    const vscodeExtensions = ".vscode/extensions.json";
+    if (opts.vscodeProject && !await host().existsAsync(vscodeExtensions)) {
+        if (!await host().existsAsync(".vscode")) await host().mkdirAsync(".vscode");
+        await host().writeFileAsync(
+            vscodeExtensions,
+            JSON.stringify({
+                recommendations: ["ms-edu.pxt-vscode-web"]
             }, null, 4)
         );
     }


### PR DESCRIPTION
hide mkc.json in the file explorer as default (in vscode extension only), and add `.vscode/extensions.json` to match default project from https://github.com/microsoft/pxt/pull/9375/files (in case they e.g. upload to github for others to use)

![image](https://user-images.githubusercontent.com/5615930/226059849-afd6c931-b760-464d-a5c3-9b1a67214375.png)
