### PR TITLE
feat: expose function to build sim JS info

### DIFF
--- a/packages/makecode-browser/src/languageService.ts
+++ b/packages/makecode-browser/src/languageService.ts
@@ -155,8 +155,7 @@ export class BrowserLanguageService implements LanguageService {
     }
 
     async buildSimJsInfoAsync(result: CompileResult): Promise<BuiltSimJsInfo> {
-        // no-op
-        return {js: "", targetVersion: ""};
+        throw new Error('Not implemented');
     }
 
     protected sendWorkerRequestAsync(message: ClientToWorkerRequest): Promise<ClientToWorkerRequestResponse> {

--- a/packages/makecode-browser/src/languageService.ts
+++ b/packages/makecode-browser/src/languageService.ts
@@ -1,5 +1,5 @@
 import { WebConfig } from "makecode-core/built/downloader";
-import { CompileOptions } from "makecode-core/built/service";
+import { BuiltSimJsInfo, CompileOptions, CompileResult } from "makecode-core/built/service";
 import { LanguageService, SimpleDriverCallbacks } from "makecode-core/built/host";
 import { DownloadedEditor, Package } from "makecode-core";
 import { workerJs } from "./workerFiles";
@@ -152,6 +152,11 @@ export class BrowserLanguageService implements LanguageService {
             type: "setCompileSwitches",
             flags
         });
+    }
+
+    async buildSimJsInfoAsync(result: CompileResult): Promise<BuiltSimJsInfo> {
+        // no-op
+        return {js: "", targetVersion: ""};
     }
 
     protected sendWorkerRequestAsync(message: ClientToWorkerRequest): Promise<ClientToWorkerRequestResponse> {

--- a/packages/makecode-browser/src/languageService.ts
+++ b/packages/makecode-browser/src/languageService.ts
@@ -155,7 +155,8 @@ export class BrowserLanguageService implements LanguageService {
     }
 
     async buildSimJsInfoAsync(result: CompileResult): Promise<BuiltSimJsInfo> {
-        throw new Error('Not implemented');
+        // If you want to implement this, figure out how to get the worker to run the pxtc.buildSimJsInfo function
+        throw new Error("Not implemented")
     }
 
     protected sendWorkerRequestAsync(message: ClientToWorkerRequest): Promise<ClientToWorkerRequestResponse> {

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -318,7 +318,7 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
 
     if (compileRes && opts.javaScript) {
         compileRes.simJsInfo = await prj.buildSimJsInfoAsync(compileRes)
-        compileRes.simJsInfo.parts = compileRes.usedParts 
+        compileRes.simJsInfo.parts = compileRes.usedParts
     }
 
     if (success) {

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -42,7 +42,7 @@ async function buildOnePrj(opts: BuildOptions, prj: mkc.Project) {
     try {
         const simpleOpts = {
             native: opts.native,
-            computeUsedParts: opts.computeUsedParts
+            computeUsedParts: opts.simulatorJavaScript,
         }
 
         const res = await prj.buildAsync(simpleOpts)
@@ -197,11 +197,11 @@ export interface BuildOptions extends ProjectOptions {
     hw?: string
     native?: boolean
     javaScript?: boolean
+    simulatorJavaScript?: boolean
     deploy?: boolean
     alwaysBuilt?: boolean
     monoRepo?: boolean
     watch?: boolean
-    computeUsedParts?: boolean
 }
 
 export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.CompileResult> {
@@ -212,6 +212,10 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
     const targetId = appTarget.id;
     let moreHw: string[] = []
     const outputs: string[] = []
+
+    if (opts.simulatorJavaScript) {
+        opts.javaScript = true
+    }
 
     if (opts.hw) {
         const hws = opts.hw.split(/[\s,;]+/)
@@ -316,7 +320,7 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
         compileRes.binaryPath = outputs[0] + "/" + firmwareName;
     }
 
-    if (compileRes && opts.javaScript) {
+    if (compileRes && opts.simulatorJavaScript) {
         compileRes.simJsInfo = await prj.buildSimJsInfoAsync(compileRes)
         compileRes.simJsInfo.parts = compileRes.usedParts
     }

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -42,6 +42,7 @@ async function buildOnePrj(opts: BuildOptions, prj: mkc.Project) {
     try {
         const simpleOpts = {
             native: opts.native,
+            computeUsedParts: opts.computeUsedParts
         }
 
         const res = await prj.buildAsync(simpleOpts)
@@ -200,6 +201,7 @@ export interface BuildOptions extends ProjectOptions {
     alwaysBuilt?: boolean
     monoRepo?: boolean
     watch?: boolean
+    computeUsedParts?: boolean
 }
 
 export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.CompileResult> {
@@ -312,6 +314,10 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
 
     if (compileRes && outputs.length && firmwareName) {
         compileRes.binaryPath = outputs[0] + "/" + firmwareName;
+    }
+
+    if (compileRes && opts.javaScript) {
+        compileRes.simJsInfo = await prj.buildSimJsInfoAsync(compileRes)
     }
 
     if (success) {

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -42,7 +42,7 @@ async function buildOnePrj(opts: BuildOptions, prj: mkc.Project) {
     try {
         const simpleOpts = {
             native: opts.native,
-            computeUsedParts: opts.simulatorJavaScript,
+            computeUsedParts: opts.buildSimJsInfo,
         }
 
         const res = await prj.buildAsync(simpleOpts)
@@ -197,7 +197,7 @@ export interface BuildOptions extends ProjectOptions {
     hw?: string
     native?: boolean
     javaScript?: boolean
-    simulatorJavaScript?: boolean
+    buildSimJsInfo?: boolean
     deploy?: boolean
     alwaysBuilt?: boolean
     monoRepo?: boolean
@@ -213,7 +213,7 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
     let moreHw: string[] = []
     const outputs: string[] = []
 
-    if (opts.simulatorJavaScript) {
+    if (opts.buildSimJsInfo) {
         opts.javaScript = true
     }
 
@@ -320,7 +320,7 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
         compileRes.binaryPath = outputs[0] + "/" + firmwareName;
     }
 
-    if (compileRes && opts.simulatorJavaScript) {
+    if (compileRes && opts.buildSimJsInfo) {
         compileRes.simJsInfo = await prj.buildSimJsInfoAsync(compileRes)
         compileRes.simJsInfo.parts = compileRes.usedParts
     }

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -318,6 +318,7 @@ export async function buildCommandOnce(opts: BuildOptions): Promise<mkc.service.
 
     if (compileRes && opts.javaScript) {
         compileRes.simJsInfo = await prj.buildSimJsInfoAsync(compileRes)
+        compileRes.simJsInfo.parts = compileRes.usedParts 
     }
 
     if (success) {

--- a/packages/makecode-core/src/host.ts
+++ b/packages/makecode-core/src/host.ts
@@ -1,6 +1,6 @@
 import { WebConfig } from "./downloader";
 import { DownloadedEditor, Package } from "./mkc";
-import { CompileOptions } from "./service";
+import { BuiltSimJsInfo, CompileOptions, CompileResult } from "./service";
 
 export interface Host {
     readFileAsync(path: string, encoding: "utf8"): Promise<string>;
@@ -68,7 +68,8 @@ export interface LanguageService {
     enableExperimentalHardwareAsync(): Promise<void>;
     enableDebugAsync(): Promise<void>;
     setCompileSwitchesAsync(flags: string): Promise<void>
-
+    buildSimJsInfoAsync(result: CompileResult): Promise<BuiltSimJsInfo>
+    
     dispose?: () => void;
 }
 

--- a/packages/makecode-core/src/host.ts
+++ b/packages/makecode-core/src/host.ts
@@ -69,7 +69,7 @@ export interface LanguageService {
     enableDebugAsync(): Promise<void>;
     setCompileSwitchesAsync(flags: string): Promise<void>
     buildSimJsInfoAsync(result: CompileResult): Promise<BuiltSimJsInfo>
-    
+
     dispose?: () => void;
 }
 

--- a/packages/makecode-core/src/mkc.ts
+++ b/packages/makecode-core/src/mkc.ts
@@ -318,13 +318,15 @@ export class Project {
                 `// meta=${JSON.stringify(meta)}\n` + res.outfiles[binjs]
         }
 
-        await this.saveBuiltFilesAsync(res)
+        const info = await this.service.languageService.buildSimJsInfoAsync(res)
+        const updatedResult: service.CompileResult = { ...res, ...info}
+        await this.saveBuiltFilesAsync(updatedResult)
 
         //delete res.outfiles
         //delete (res as any).procDebugInfo
         //console.log(res)
 
-        return res
+        return updatedResult
     }
 
     async mkChildProjectAsync(folder: string) {

--- a/packages/makecode-core/src/mkc.ts
+++ b/packages/makecode-core/src/mkc.ts
@@ -318,15 +318,17 @@ export class Project {
                 `// meta=${JSON.stringify(meta)}\n` + res.outfiles[binjs]
         }
 
-        const info = await this.service.languageService.buildSimJsInfoAsync(res)
-        const updatedResult: service.CompileResult = { ...res, ...info}
-        await this.saveBuiltFilesAsync(updatedResult)
+        await this.saveBuiltFilesAsync(res)
 
         //delete res.outfiles
         //delete (res as any).procDebugInfo
         //console.log(res)
 
-        return updatedResult
+        return res
+    }
+
+    async buildSimJsInfoAsync(result: service.CompileResult) {
+        return await this.service.buildSimJsInfoAsync(result)
     }
 
     async mkChildProjectAsync(folder: string) {

--- a/packages/makecode-core/src/service.ts
+++ b/packages/makecode-core/src/service.ts
@@ -94,6 +94,7 @@ export interface CompileResult {
     times: pxt.Map<number>
     // breakpoints?: Breakpoint[];
     usedArguments?: pxt.Map<string[]>
+    usedParts?: string[]
     binaryPath?: string;
     simJsInfo?: BuiltSimJsInfo
 }

--- a/packages/makecode-core/src/service.ts
+++ b/packages/makecode-core/src/service.ts
@@ -243,7 +243,8 @@ export class Ctx {
             )
             for (const info of infos) await this.compileExtInfo(info)
         }
-        
+
+        // Manually set this option for now
         if (simpleOpts.computeUsedParts) opts.computeUsedParts = true
 
         // opts.breakpoints = true

--- a/packages/makecode-core/src/service.ts
+++ b/packages/makecode-core/src/service.ts
@@ -50,6 +50,16 @@ export interface CompileOptions {
     otherMultiVariants?: ExtensionTarget[]
 }
 
+export interface BuiltSimJsInfo {
+    js: string
+    targetVersion: string
+    fnArgs?: pxt.Map<String[]>
+    parts?: string[]
+    usedBuiltinParts?: string[]
+    allParts?: string[]
+    breakpoints?: number[]
+}
+
 export enum DiagnosticCategory {
     Warning = 0,
     Error = 1,
@@ -76,7 +86,7 @@ export interface KsDiagnostic extends LocationInfo {
     messageText: string | DiagnosticMessageChain
 }
 
-export interface CompileResult {
+export interface CompileResult extends Partial<BuiltSimJsInfo> {
     outfiles: pxt.Map<string>
     diagnostics: KsDiagnostic[]
     success: boolean

--- a/packages/makecode-core/src/service.ts
+++ b/packages/makecode-core/src/service.ts
@@ -38,6 +38,7 @@ export interface CompileOptions {
     trace?: boolean
     justMyCode?: boolean
     computeUsedSymbols?: boolean
+    computeUsedParts?: boolean
     name?: string
     warnDiv?: boolean // warn when emitting division operator
     bannedCategories?: string[]
@@ -94,6 +95,7 @@ export interface CompileResult {
     // breakpoints?: Breakpoint[];
     usedArguments?: pxt.Map<string[]>
     binaryPath?: string;
+    simJsInfo?: BuiltSimJsInfo
 }
 
 export interface ServiceUser {
@@ -232,7 +234,7 @@ export class Ctx {
         prj: mkc.Package,
         simpleOpts: any = {}
     ): Promise<CompileResult> {
-        const opts = await this.getOptionsAsync(prj, simpleOpts)
+        let opts = await this.getOptionsAsync(prj, simpleOpts)
 
         if (simpleOpts.native && opts?.extinfo?.sha) {
             const infos = [opts.extinfo].concat(
@@ -240,6 +242,8 @@ export class Ctx {
             )
             for (const info of infos) await this.compileExtInfo(info)
         }
+        
+        if (simpleOpts.computeUsedParts) opts.computeUsedParts = true
 
         // opts.breakpoints = true
         return this.languageService.performOperationAsync("compile", { options: opts })

--- a/packages/makecode-core/src/service.ts
+++ b/packages/makecode-core/src/service.ts
@@ -86,7 +86,7 @@ export interface KsDiagnostic extends LocationInfo {
     messageText: string | DiagnosticMessageChain
 }
 
-export interface CompileResult extends Partial<BuiltSimJsInfo> {
+export interface CompileResult {
     outfiles: pxt.Map<string>
     diagnostics: KsDiagnostic[]
     success: boolean
@@ -243,6 +243,10 @@ export class Ctx {
 
         // opts.breakpoints = true
         return this.languageService.performOperationAsync("compile", { options: opts })
+    }
+
+    async buildSimJsInfoAsync(result: CompileResult): Promise<BuiltSimJsInfo> {
+        return await this.languageService.buildSimJsInfoAsync(result);
     }
 
     private async setHwVariantAsync(prj: mkc.Package) {

--- a/packages/makecode-node/src/cli.ts
+++ b/packages/makecode-node/src/cli.ts
@@ -197,10 +197,6 @@ async function mainCli() {
             "set hardware(s) for which to compile (implies -n)"
         )
         .option("-j, --java-script", "compile to JavaScript")
-        .option(
-            "-s, --simulator-java-script",
-            "compile to JavaScript and include simulator JS info (implies -j)"
-        )
         .option("-u, --update", "check for web-app updates")
         .option(
             "-c, --config-path <file>",

--- a/packages/makecode-node/src/cli.ts
+++ b/packages/makecode-node/src/cli.ts
@@ -63,8 +63,10 @@ export async function buildCommand(opts: BuildOptions, info: Command) {
         error("--deploy and --mono-repo cannot be used together")
         process.exit(1)
     }
-    if (opts.deploy && opts.javaScript) {
-        error("--deploy and --java-script cannot be used together")
+    if (opts.deploy && (opts.javaScript || opts.simulatorJavaScript)) {
+        error(
+            "--deploy and (--java-script or --simulator-java-script) cannot be used together"
+        )
         process.exit(1)
     }
     if (opts.watch) {
@@ -195,6 +197,10 @@ async function mainCli() {
             "set hardware(s) for which to compile (implies -n)"
         )
         .option("-j, --java-script", "compile to JavaScript")
+        .option(
+            "-s, --simulator-java-script",
+            "compile to JavaScript and include simulator JS info (implies -j)"
+        )
         .option("-u, --update", "check for web-app updates")
         .option(
             "-c, --config-path <file>",

--- a/packages/makecode-node/src/cli.ts
+++ b/packages/makecode-node/src/cli.ts
@@ -63,10 +63,8 @@ export async function buildCommand(opts: BuildOptions, info: Command) {
         error("--deploy and --mono-repo cannot be used together")
         process.exit(1)
     }
-    if (opts.deploy && (opts.javaScript || opts.simulatorJavaScript)) {
-        error(
-            "--deploy and (--java-script or --simulator-java-script) cannot be used together"
-        )
+    if (opts.deploy && opts.javaScript) {
+        error("--deploy and --java-script cannot be used together")
         process.exit(1)
     }
     if (opts.watch) {

--- a/packages/makecode-node/src/languageService.ts
+++ b/packages/makecode-node/src/languageService.ts
@@ -3,7 +3,7 @@ import * as util from "util";
 
 import * as mkc from "makecode-core/built/mkc";
 import { WebConfig } from "makecode-core/built/downloader";
-import { CompileOptions } from "makecode-core/built/service";
+import { BuiltSimJsInfo, CompileOptions, CompileResult } from "makecode-core/built/service";
 import { LanguageService, SimpleDriverCallbacks } from "makecode-core/built/host";
 
 export class NodeLanguageService implements LanguageService {
@@ -136,6 +136,10 @@ export class NodeLanguageService implements LanguageService {
             if (pxt.appTarget.compile.switches.asmdebug)
                 ts.pxtc.assembler.debug = 1
         })()`)
+    }
+
+    async buildSimJsInfoAsync(result: CompileResult): Promise<BuiltSimJsInfo> {
+        return this.runFunctionSync("pxtc.buildSimJsInfo", [result])
     }
 
     private runScript(content: string, filename: string) {


### PR DESCRIPTION
Create `buildSimJsInfo` function to add `BuiltSimJsInfo` information to the compiled JavaScript result.