### PR TITLE
fix: Downgrade to semantic release 21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
-
 {
-    "private": true,
-    "scripts": {
-    },
-    "devDependencies": {
-    },
-    "workspaces": [
-      "packages/*"
-    ]
-  }
+  "private": true,
+  "scripts": {},
+  "devDependencies": {
+    "semantic-release": "^21.0.0"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}


### PR DESCRIPTION
The semantic-release build step is currently broken. Specifically, while running the semantic-release-monrepo plugin's `analyzeCommits` step. Try pinning the major version to 21.