### PR TITLE
use editor url for share links

### DIFF
--- a/packages/makecode-core/src/share.ts
+++ b/packages/makecode-core/src/share.ts
@@ -46,7 +46,10 @@ export async function shareProjectAsync(opts: ProjectOptions) {
     const prj = await resolveProject(opts);
     const req = await createShareLinkRequestAsync(prj);
 
-    let siteRoot = prj.editor.website;
+    let siteRoot = new URL(prj.editor.website).origin;
+    if (!siteRoot.endsWith("/")) {
+        siteRoot += "/";
+    }
 
     const res = await host().requestAsync({
         url: apiRoot + "/api/scripts",
@@ -55,9 +58,6 @@ export async function shareProjectAsync(opts: ProjectOptions) {
 
     if (res.statusCode === 200) {
         const resJSON = JSON.parse(res.text!)
-        if (!siteRoot.endsWith("/")) {
-            siteRoot += "/";
-        }
         return siteRoot + resJSON.shortid
     }
 


### PR DESCRIPTION
the share command currently always outputs share links in the form `www.makecode.com/_xxxxxxxx` which *works*, but doesn't match what our editors return (e.g. `arcade.makecode.com/_xxxxxxxx`). the generic `makecode.com/` links don't work with the import project button on the homescreen or in the extensions dialog.

this pr grabs the editor URL from the project and uses that as the root for the share link instead.