### PR TITLE
Add command for getting a single sim html file and loading it in iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,14 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.9.8",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+            "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+            "engines": {
+                "node": ">=14.6"
+            }
+        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -314,6 +322,7 @@
             "version": "1.6.3",
             "license": "MIT",
             "dependencies": {
+                "@xmldom/xmldom": "^0.9.8",
                 "chalk": "^4.1.2"
             },
             "devDependencies": {

--- a/packages/makecode-core/package.json
+++ b/packages/makecode-core/package.json
@@ -42,6 +42,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
+    "@xmldom/xmldom": "^0.9.8",
     "chalk": "^4.1.2"
   },
   "release": {

--- a/packages/makecode-core/simloader/loader.ts
+++ b/packages/makecode-core/simloader/loader.ts
@@ -113,9 +113,9 @@ function makeCodeRun(options) {
                 }
                 else {
                     iframe.setAttribute("src", meta.simUrl + "#" + frameid);
+                    let m = /^https?:\/\/[^\/]+/.exec(meta.simUrl);
+                    simOrigin = m[0];
                 }
-                let m = /^https?:\/\/[^\/]+/.exec(meta.simUrl);
-                simOrigin = m[0];
                 initFullScreen();
             })
     }
@@ -162,7 +162,18 @@ function makeCodeRun(options) {
         function (ev) {
             let d = ev.data;
             console.log(ev.origin, d)
-            if (ev.origin == simOrigin) {
+
+            let isSim = false;
+
+            if (simOrigin) {
+                isSim = ev.origin === simOrigin;
+            }
+            else {
+                const iframe = this.document.getElementById("simframe") as HTMLIFrameElement;
+                isSim = ev.source === iframe.contentWindow;
+            }
+
+            if (isSim) {
                 if (d.req_seq) {
                     postMessageToParentAsync(d);
                     return;
@@ -270,7 +281,7 @@ function makeCodeRun(options) {
 
     function postMessage(msg) {
         const frame = document.getElementById("simframe") as HTMLIFrameElement
-        if (meta && frame) frame.contentWindow.postMessage(msg, meta.simUrl);
+        if (meta && frame) frame.contentWindow.postMessage(msg, simOrigin ? meta.simUrl : "*");
     }
 
     function initSimState() {

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -1,6 +1,6 @@
 import * as path from "path"
 import * as chalk from "chalk"
-import { DOMParser, XMLSerializer } from "@xmldom/xmldom";
+import { DOMParser, XMLSerializer, Element } from "@xmldom/xmldom";
 
 import * as mkc from "./mkc"
 import * as files from "./files"
@@ -952,6 +952,8 @@ export async function getSimHTML(opts: ProjectOptions) {
         element.textContent = `\n${host().bufferToString(contents)}\n`
     }
 
+    const toRemove: Element[] = [];
+
     for (const element of dom.getElementsByTagName("link")) {
         if (!element.hasAttribute("href")) continue;
 
@@ -978,6 +980,10 @@ export async function getSimHTML(opts: ProjectOptions) {
         const newStyle = dom.createElement("style");
         newStyle.textContent = `\n${host().bufferToString(contents)}\n`;
         element.parentElement.insertBefore(newStyle, element);
+        toRemove.push(element);
+    }
+
+    for (const element of toRemove) {
         element.parentElement.removeChild(element);
     }
 


### PR DESCRIPTION
this adds a command to pxt-mkc for getting the html file of the sim, which mkc already downloads when it downloads the editor. to simplify serving the file, the code also inlines all of the javascript and css into one monolithic html file. for the inlining part i added a dependency to [\@xmldom/xmldom](https://www.npmjs.com/package/@xmldom/xmldom) since domparser is not available in node or in a webworker context (which is where the vscode extension runs).

this pr also adds a new optional srcDoc parameter to the fetch-js message which gets sent to the simloader page that is hosted by `makecode serve` and the vscode extension. when that parameter is specified, the loader will use it to [populate the sim iframe](https://developer.mozilla.org/en-US/docs/Web/API/HTMLIFrameElement/srcdoc) instead of using the URL from the meta information in the compiled binary.js. all of this is to support serving the simulator offline from the vscode extension!