### PR TITLE
add asseteditor to mkc cache and fix webconfig parsing

### DIFF
--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -925,64 +925,94 @@ export async function getSimHTML(opts: ProjectOptions) {
     const cache = await project.getCacheAsync();
 
     const key = project.editor.website + "-sim.html"
+    return (await getExpandedPageFromCache(key, cache, project.editor.website));
+}
 
-    let simHTML = host().bufferToString(await cache.getAsync(key));
+export async function getAssetEditorHTML(opts: ProjectOptions) {
+    applyGlobalOptions(opts);
 
-    const dom = new DOMParser().parseFromString(simHTML, "text/html");
+    const project = await resolveProject(opts);
+    const cache = await project.getCacheAsync();
 
-    for (const element of dom.getElementsByTagName("script")) {
-        if (!element.hasAttribute("src")) continue;
+    const key = project.editor.website + "-asseteditor.html"
+    return getExpandedPageFromCache(key, cache, project.editor.website);
+}
 
-        const srcPath = element.getAttribute("src");
-        let filename: string;
+async function getExpandedPageFromCache(cacheKey: string, cache: mkc.Cache, website: string): Promise<string> {
+    const pageHTML = host().bufferToString(await cache.getAsync(cacheKey));
 
-        if (srcPath.indexOf("/") !== -1) {
-            filename = srcPath.split("/").pop();
-        }
-        else {
-            filename = srcPath.split("-").pop();
-        }
-        const key = project.editor.website + "-" + filename;
-
-        const contents = await cache.getAsync(key);
-
-        if (!contents) continue;
-
-        element.removeAttribute("src");
-        element.textContent = `\n${host().bufferToString(contents)}\n`
-    }
-
+    const dom = new DOMParser().parseFromString(pageHTML, "text/html");
+    const scripts: string[] = [];
     const toRemove: Element[] = [];
 
-    for (const element of dom.getElementsByTagName("link")) {
-        if (!element.hasAttribute("href")) continue;
+    const processElement = async (element: Element, srcAttribute: string, fileExtension: string) => {
+        if (!element.hasAttribute(srcAttribute)) return undefined;
 
-        const srcPath = element.getAttribute("href");
-        let filename: string;
+        const srcPath = element.getAttribute(srcAttribute);
 
-        if (!srcPath.endsWith(".css")) continue;
+        if (!srcPath.endsWith(fileExtension)) return undefined;
 
-        if (srcPath.indexOf("/") !== -1) {
-            filename = srcPath.split("/").pop();
+        let filename = srcPath;
+        if (srcPath.startsWith(website)) {
+            filename = srcPath.slice(website.length);
+        }
+
+        if (filename.indexOf("/") !== -1) {
+            filename = filename.split("/").pop();
         }
         else {
-            filename = srcPath.split("-").pop();
+            filename = filename.split("-").pop();
         }
-        const key = project.editor.website + "-" + filename;
+        const key = website + "-" + filename;
 
         const contents = await cache.getAsync(key);
 
-        if (!contents) continue;
+        if (!contents) return undefined;
+        let contentString = host().bufferToString(contents);
 
-        const newStyle = dom.createElement("style");
-        newStyle.textContent = `\n${host().bufferToString(contents)}\n`;
-        element.parentElement.insertBefore(newStyle, element);
+        return contentString.trim();
+    };
+
+    for (const element of dom.getElementsByTagName("script")) {
+        const contentString = await processElement(element, "src", ".js");
+
+        if (contentString) {
+            scripts.push(btoa(encodeURIComponent(contentString)));
+        }
+        else {
+            scripts.push(btoa(encodeURIComponent(element.textContent)));
+        }
+
         toRemove.push(element);
+    }
+
+    for (const element of dom.getElementsByTagName("link")) {
+        const contentString = await processElement(element, "href", ".css");
+
+        if (contentString) {
+            const newStyle = dom.createElement("style");
+            newStyle.textContent = `\n${contentString}\n`;
+            element.parentElement.insertBefore(newStyle, element);
+            toRemove.push(element);
+        }
     }
 
     for (const element of toRemove) {
         element.parentElement.removeChild(element);
     }
+
+    const metaScript = `
+        const allScripts = [\`${scripts.join("`,`")}\`];
+        for (const scriptEntry of allScripts) {
+            const el = document.createElement("script");
+            el.textContent = decodeURIComponent(atob(scriptEntry));
+            document.head.appendChild(el);
+        }
+    `;
+
+    const scriptElement = dom.createElement("script");
+    scriptElement.textContent = metaScript;
+    dom.getElementsByTagName("head").item(0).appendChild(scriptElement);
 
     return new XMLSerializer().serializeToString(dom);
 }

--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -925,7 +925,7 @@ export async function getSimHTML(opts: ProjectOptions) {
     const cache = await project.getCacheAsync();
 
     const key = project.editor.website + "-sim.html"
-    return (await getExpandedPageFromCache(key, cache, project.editor.website));
+    return getExpandedPageFromCache(key, cache, project.editor.website);
 }
 
 export async function getAssetEditorHTML(opts: ProjectOptions) {

--- a/packages/makecode-core/src/downloader.ts
+++ b/packages/makecode-core/src/downloader.ts
@@ -231,11 +231,9 @@ export async function downloadAsync(
 
     if (cache.rootPath) {
         info.simKey = webAppUrl + "-sim.html"
-
         await downloadPageAndDependenciesAsync(cfg.simUrl, info.simKey);
 
         info.assetEditorKey = webAppUrl + "-asseteditor.html";
-        debugger;
         await downloadPageAndDependenciesAsync(webAppUrl + "---asseteditor", info.assetEditorKey);
     }
 

--- a/packages/makecode-core/src/downloader.ts
+++ b/packages/makecode-core/src/downloader.ts
@@ -2,6 +2,8 @@ import * as mkc from "./mkc"
 
 import { host } from "./host";
 
+import { DOMParser, Element, XMLSerializer } from "@xmldom/xmldom";
+
 export interface HttpRequestOptions {
     url: string
     method?: string // default to GET
@@ -133,6 +135,7 @@ export interface DownloadInfo {
     manifestEtag?: string
     cdnUrl?: string
     simKey?: string
+    assetEditorKey?: string;
     versionNumber?: number
     updateCheckedAt?: number
     webConfig?: WebConfig
@@ -227,27 +230,13 @@ export async function downloadAsync(
     info.targetConfig = targetConfig;
 
     if (cache.rootPath) {
-        let simTxt = await httpGetTextAsync(cfg.simUrl)
-        const simurls: string[] = []
-        const simkey: pxt.Map<string> = {}
-        simTxt = simTxt.replace(/https:\/\/[\w\/\.\-]+/g, f => {
-            if (f.startsWith(info.cdnUrl)) {
-                simurls.push(f)
-                const base = f.replace(/.*\//, "")
-                simkey[f] = webAppUrl + "-" + base
-                return cache.expandKey(simkey[f])
-            }
-            return f
-        })
-        simTxt = simTxt.replace(/ manifest=/, " x-manifest=")
-
         info.simKey = webAppUrl + "-sim.html"
 
-        await cache.setAsync(info.simKey, host().stringToBuffer(simTxt))
-        for (let url of simurls) {
-            const resp = await requestAsync({ url })
-            await cache.setAsync(simkey[url], resp.buffer)
-        }
+        await downloadPageAndDependenciesAsync(cfg.simUrl, info.simKey);
+
+        info.assetEditorKey = webAppUrl + "-asseteditor.html";
+        debugger;
+        await downloadPageAndDependenciesAsync(webAppUrl + "---asseteditor", info.assetEditorKey);
     }
 
     return loadFromCacheAsync()
@@ -312,5 +301,45 @@ export async function downloadAsync(
 
         info.manifest = resp.text
         return true
+    }
+
+    async function downloadPageAndDependenciesAsync(url: string, cacheKey: string) {
+        let pageText = await httpGetTextAsync(url);
+
+        const dom = new DOMParser().parseFromString(pageText, "text/html");
+
+        const additionalUrls: string[] = []
+        const urlKeyMap: pxt.Map<string> = {}
+
+        for (const script of dom.getElementsByTagName("script")) {
+            if (!script.hasAttribute("src")) continue;
+
+            const url = script.getAttribute("src");
+            if (!url.startsWith(info.cdnUrl) || !url.endsWith(".js")) continue;
+
+            additionalUrls.push(url);
+            urlKeyMap[url] = webAppUrl + "-" + url.replace(/.*\//, "");
+            script.setAttribute("src", cache.expandKey(urlKeyMap[url]));
+        }
+
+        for (const link of dom.getElementsByTagName("link")) {
+            if (!link.hasAttribute("href")) continue;
+
+            const url = link.getAttribute("href");
+            if (!url.startsWith(info.cdnUrl) || !url.endsWith(".css")) continue;
+
+            additionalUrls.push(url);
+            urlKeyMap[url] = webAppUrl + "-" + url.replace(/.*\//, "");
+            link.setAttribute("href", cache.expandKey(urlKeyMap[url]));
+        }
+
+        pageText = new XMLSerializer().serializeToString(dom);
+        pageText = pageText.replace(/ manifest=/, " x-manifest=")
+
+        await cache.setAsync(cacheKey, host().stringToBuffer(pageText))
+        for (let url of additionalUrls) {
+            const resp = await requestAsync({ url })
+            await cache.setAsync(urlKeyMap[url], resp.buffer)
+        }
     }
 }


### PR DESCRIPTION
this pr:
* fixes the parsing of the webconfig from index.html which was using a regex that got broken by the recent OCV changes in the backend
* adds the /---asseteditor endpoint to the locally cached files so that we can serve it locally in the vscode extension
* improves the HTML inlining code from my last PR

the reason for the changes to the HTML inlining code is that the asseteditor references pxtapp.js which includes a bunch of open and close `<script>` tags that were confusing chrome's HTML parser. now all scripts are base64 encoded and inlined into the HTML file where a tiny piece of JS decodes them and adds them to the page after the DOM is parsed. the downside of this approach is that the file we generate is now much, much bigger than before, but i can't think of any alternatives at the moment