### PR TITLE
improve page expanding and cache results in mkc cache

### DIFF
--- a/packages/makecode-core/src/downloader.ts
+++ b/packages/makecode-core/src/downloader.ts
@@ -141,6 +141,9 @@ export interface DownloadInfo {
     webConfig?: WebConfig
     targetVersion?: string
     targetConfig?: any //  see pxt/localtypings/pxtarget.d.ts interface TargetConfig
+
+    cachedAssetEditorKey?: string;
+    cachedSimulatorKey?: string;
 }
 
 function log(msg: string) {
@@ -236,6 +239,9 @@ export async function downloadAsync(
         info.assetEditorKey = webAppUrl + "-asseteditor.html";
         await downloadPageAndDependenciesAsync(webAppUrl + "---asseteditor", info.assetEditorKey);
     }
+
+    delete info.cachedAssetEditorKey;
+    delete info.cachedSimulatorKey;
 
     return loadFromCacheAsync()
 

--- a/packages/makecode-core/src/host.ts
+++ b/packages/makecode-core/src/host.ts
@@ -22,6 +22,7 @@ export interface Host {
 
     bufferToString(buffer: Uint8Array): string;
     stringToBuffer (str: string, encoding?: "utf8" | "base64"): Uint8Array;
+    base64EncodeBufferAsync(buffer: Uint8Array): Promise<string>;
 
     guidGen?(): string;
 }

--- a/packages/makecode-node/src/nodeHost.ts
+++ b/packages/makecode-node/src/nodeHost.ts
@@ -31,6 +31,7 @@ export function createNodeHost(): Host {
         cwdAsync: async () => process.cwd(),
         bufferToString: buffer => new util.TextDecoder("utf8").decode(buffer),
         stringToBuffer: (str, encoding) => Buffer.from(str, encoding),
+        base64EncodeBufferAsync: async buffer => Buffer.isBuffer(buffer) ? buffer.toString("base64") : Buffer.from(buffer).toString("base64"),
         guidGen: () => crypto.randomUUID()
     }
 }


### PR DESCRIPTION
this PR improves the page expanding for asseteditor.html so that it also inlines all of the PNG icons for the music editor. fetching all of those icons involves making a lot of requests, so i also made it so that the expanded file is now stored in the cache along with the expanded sim.html so that we don't re-calculate them every time you click on a new asset. finally, i also removed the btoa encoding on the inlined scripts because it turns out the encodeURIComponent is already enough.

@aznhassan i don't know if your script compilation implements the host, but FYI this adds one additional API to the host interface so if you take this mkc update you'll need to implement it (or include a dummy implementation since it won't actually get called in your scenario). i'll also need to update the vscode extension but i've already done that locally.