### PR TITLE
fix parsing of micro:bit webconfig

### DIFF
--- a/packages/makecode-core/src/downloader.ts
+++ b/packages/makecode-core/src/downloader.ts
@@ -107,7 +107,7 @@ async function parseWebConfigAsync(url: string): Promise<WebConfig | null> {
             if (line.indexOf("{") !== -1) {
                 openBrackets++;
             }
-            else if (line.indexOf("}") !== -1) {
+            if (line.indexOf("}") !== -1) {
                 openBrackets--;
 
                 if (openBrackets === 0) {


### PR DESCRIPTION
fixes https://github.com/microsoft/pxt-mkc/issues/134

the micro:bit webconfig has no ocv data so it ends up looking like this:
```
    "ocv": {}
```

which broke my parsing. fix is simply switching from and else-if to an if