### PR TITLE
add command to fetch webconfig

### DIFF
--- a/packages/makecode-core/src/commands.ts
+++ b/packages/makecode-core/src/commands.ts
@@ -922,6 +922,14 @@ export async function getSimHTML(opts: ProjectOptions) {
     return getExpandedHTML(opts, "cachedSimulatorKey", "sim");
 }
 
+export async function getWebConfig(opts: ProjectOptions) {
+    applyGlobalOptions(opts);
+
+    const project = await resolveProject(opts);
+
+    return project.editor.webConfig;
+}
+
 export async function getAssetEditorHTML(opts: ProjectOptions) {
     return getExpandedHTML(opts, "cachedAssetEditorKey", "asseteditor");
 }


### PR DESCRIPTION
this is needed for the simx support in the simulator of the vscode extension; we need to fetch the simulator url from the webconfig