### PR TITLE
parse commit message instead of tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,3 +66,4 @@ jobs:
         run: node ./scripts/release.js publish
         env:
           NPM_ACCESS_TOKEN: ${{ secrets.NPM_TOKEN }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -92,20 +92,21 @@ async function bump(packageDirectory, versionType) {
 }
 
 function publish() {
-    if (process.env.GITHUB_REF_TYPE !== "tag") {
-        console.error("Workflow not invoked by a tagged commit. Aborting.");
+    if (process.env.CI !== "true") {
+        console.error("This command is only meant to be run in GitHub Actions");
         process.exit(0);
     }
 
-    const tag = process.env.GITHUB_REF_NAME;
-
-    const match = /^([a-z\-]+)-v\d+.\d+.\d+$/.exec(tag);
+    const commitMessage = process.env.COMMIT_MESSAGE?.trim();
+    const match = /^\[release\] bump version to (makecode-core|makecode-browser|makecode)-v[0-9]+\.[0-9]+\.[0-9]+$/.exec(commitMessage);
 
     if (!match) {
         console.error("Not a release tag. Aborting");
         process.exit(0);
     }
     const packageName = match[1];
+
+    console.log(`Publishing package: ${packageName}`);
     const packageDirectory = getPackageDirectory(packageName);
 
     const npmToken = process.env.NPM_ACCESS_TOKEN;


### PR DESCRIPTION
fix publish script. we can no longer use the tag environment variable because that isn't what triggers the workflow