### PR TITLE
fix post message in sim loader

### DIFF
--- a/packages/makecode-core/simloader/loader.ts
+++ b/packages/makecode-core/simloader/loader.ts
@@ -64,7 +64,7 @@ function makeCodeRun(options) {
             });
         }
         return fetch(options.js)
-            .then(async resp => resp.status == 200 ? { text: await resp.text() } : undefined);
+            .then(async resp => resp.status == 200 ? { text: (await resp.text()) } : undefined);
     }
 
     // helpers
@@ -161,8 +161,6 @@ function makeCodeRun(options) {
         "message",
         function (ev) {
             let d = ev.data;
-            console.log(ev.origin, d)
-
             let isSim = false;
 
             if (simOrigin) {
@@ -318,8 +316,8 @@ function makeCodeRun(options) {
                 }
                 _vsapi.postMessage(message);
             }
-            else {
-                window.postMessage(message);
+            else if (window.parent !== window) {
+                window.parent.postMessage(message);
             }
         });
     }


### PR DESCRIPTION
a couple fixes for the simloader:

1. removing the console.log that logs all messages because it really clogs up the console
2. fixing postMessageToParentAsync so it doesn't just repost the messages on the current window