### PR TITLE
[release] bump version to makecode-core-v1.7.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -319,7 +319,7 @@
             }
         },
         "packages/makecode-core": {
-            "version": "1.7.8",
+            "version": "1.7.9",
             "license": "MIT",
             "dependencies": {
                 "@xmldom/xmldom": "^0.9.8",

--- a/packages/makecode-core/package.json
+++ b/packages/makecode-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makecode-core",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "MakeCode (PXT) - web-cached build tool",
   "keywords": [
     "TypeScript",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `node ./scripts/release.js bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.