### PR TITLE
[release] bump version to makecode-browser-v1.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,7 @@
             "license": "ISC"
         },
         "packages/makecode-browser": {
-            "version": "1.3.4",
+            "version": "1.3.5",
             "license": "MIT",
             "dependencies": {
                 "makecode-core": "^1.7.3"

--- a/packages/makecode-browser/package.json
+++ b/packages/makecode-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makecode-browser",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "MakeCode (PXT) - web-cached build tool",
   "keywords": [
     "TypeScript",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `node ./scripts/release.js bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.