### PR TITLE
[release] bump version to makecode-v1.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -336,7 +336,7 @@
         },
         "packages/makecode-node": {
             "name": "makecode",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2",

--- a/packages/makecode-node/package.json
+++ b/packages/makecode-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "makecode",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "MakeCode (PXT) - web-cached build tool",
   "keywords": [
     "TypeScript",


### PR DESCRIPTION
__Do not edit the PR title.__
It was automatically generated by `node ./scripts/release.js bump` and must follow a specific pattern.
GitHub workflows rely on it to trigger version tagging and publishing to npm.